### PR TITLE
Remove -Zc:__cplusplus build flag

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,6 @@ lib_deps =
     https://github.com/bblanchon/ArduinoJson.git
     https://github.com/arduino-libraries/NTPClient.git
     https://github.com/lewisxhe/BMA423_Library.git
-build_flags = -Zc:__cplusplus
 build_unflags = -Werror=all
 
 [env:watchy-v1-v2]


### PR DESCRIPTION
Removes the build flag `-Zc:__cplusplus`, which can cause compilation to fail on some systems:

```sh
Compiling .pio/build/watchy-v1-v2/src/ArduinoNvs.cpp.o
xtensa-esp32-elf-g++: error: unrecognized command line option '-Zc:__cplusplus'
Compiling .pio/build/watchy-v1-v2/src/GSR.ino.cpp.o
*** [.pio/build/watchy-v1-v2/src/ArduinoNvs.cpp.o] Error 1
xtensa-esp32-elf-g++: error: unrecognized command line option '-Zc:__cplusplus'
*** [.pio/build/watchy-v1-v2/src/GSR.ino.cpp.o] Error 1
```